### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive reference implementation for the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) that demonstrates all features of the protocol. This server showcases the versatility and extensibility of MCP, demonstrating how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources.
 
+<a href="https://glama.ai/mcp/servers/@soriat/soria-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@soriat/soria-mcp/badge" alt="Elicitations Demo Server MCP server" />
+</a>
+
 This server is built with the [TypeScript MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk).
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [MCP Elicitations Demo Server](https://glama.ai/mcp/servers/@soriat/soria-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@soriat/soria-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@soriat/soria-mcp/badge" alt="Elicitations Demo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.